### PR TITLE
fix: Handle 503 errors in parser

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ontu-parser"
-version = "1.0.0"
-description = "Add your description here"
+version = "1.0.1"
+description = "Parser for the Schedule of the Odessa National Technical University (ONTU) schedule website."
 readme = "README.md"
 authors = [
     { name = "Pavlo Pohorieltsev", email = "49622129+makisukurisu@users.noreply.github.com" }
@@ -18,10 +18,11 @@ dependencies = [
 
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Natural Language :: English",
 ]
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 
 [project.urls]
 "Homepage" = "https://github.com/Wandering-Cursor/rozklad-ontu-parser"

--- a/src/ontu_parser/errors.py
+++ b/src/ontu_parser/errors.py
@@ -31,7 +31,7 @@ class RequestError(BaseError):
         )
 
 
-class ParingError(BaseError):
+class ParsingError(BaseError):
     def __init__(
         self,
         message: str,
@@ -48,3 +48,6 @@ class ParingError(BaseError):
                 "underlying_error": underlying_error,
             }
         )
+
+
+ParingError = ParsingError  # Compatibility alias, will be deprecated in 1.1.0

--- a/src/ontu_parser/errors.py
+++ b/src/ontu_parser/errors.py
@@ -32,11 +32,19 @@ class RequestError(BaseError):
 
 
 class ParingError(BaseError):
-    def __init__(self, message: str, content: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        content: str | None = None,
+        underlying_error: Exception | None = None,
+    ) -> None:
         self.content = content
+        self.underlying_error = underlying_error
+
         super().__init__(
             {
                 "msg": message,
                 "content": content,
+                "underlying_error": underlying_error,
             }
         )

--- a/src/ontu_parser/parser/_async.py
+++ b/src/ontu_parser/parser/_async.py
@@ -14,6 +14,7 @@ from ontu_parser.dataclasses.pair import StudentsPair, TeachersPair
 from ontu_parser.dataclasses.sender import SenderOptions
 from ontu_parser.errors import ParsingError
 from ontu_parser.utils.request_sender import AsyncRequestSender
+from ontu_parser.utils.text import trim_text
 
 
 class AsyncParser(BaseClass):
@@ -41,14 +42,24 @@ class AsyncParser(BaseClass):
             response.raise_for_status()
         except HTTPStatusError as e:
             raise ParsingError(
-                "Failed to get page!",
-                content=str(response),
+                message=str(e),
+                content=trim_text(
+                    response.content.decode("utf-8", errors="ignore") if response.content else ""
+                ),
                 underlying_error=e,
             ) from e
 
         content = response.content
+
         if not content:
-            raise ParsingError("Response has no content!", content=str(response))
+            raise ParsingError(
+                "Response has no content!",
+                content=trim_text(
+                    response.content.decode("utf-8", errors="ignore") if response.content else ""
+                ),
+                underlying_error=None,
+            )
+
         decoded_content = content.decode("utf-8")
 
         return BeautifulSoup(decoded_content, "html.parser")

--- a/src/ontu_parser/parser/_async.py
+++ b/src/ontu_parser/parser/_async.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from httpx import Response
+from httpx import HTTPStatusError, Response
 
 from ontu_parser.dataclasses import (
     Department,
@@ -37,10 +37,20 @@ class AsyncParser(BaseClass):
             self.sender = AsyncRequestSender()
 
     def _get_page(self, response: Response) -> BeautifulSoup:
+        try:
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            raise ParingError(
+                "Failed to get page!",
+                content=str(response),
+                underlying_error=e,
+            ) from e
+
         content = response.content
         if not content:
             raise ParingError("Response has no content!", content=str(response))
         decoded_content = content.decode("utf-8")
+
         return BeautifulSoup(decoded_content, "html.parser")
 
     async def is_on_break(self) -> bool:

--- a/src/ontu_parser/parser/_async.py
+++ b/src/ontu_parser/parser/_async.py
@@ -12,7 +12,7 @@ from ontu_parser.dataclasses import (
 from ontu_parser.dataclasses.base import BaseClass
 from ontu_parser.dataclasses.pair import StudentsPair, TeachersPair
 from ontu_parser.dataclasses.sender import SenderOptions
-from ontu_parser.errors import ParingError
+from ontu_parser.errors import ParsingError
 from ontu_parser.utils.request_sender import AsyncRequestSender
 
 
@@ -40,7 +40,7 @@ class AsyncParser(BaseClass):
         try:
             response.raise_for_status()
         except HTTPStatusError as e:
-            raise ParingError(
+            raise ParsingError(
                 "Failed to get page!",
                 content=str(response),
                 underlying_error=e,
@@ -48,7 +48,7 @@ class AsyncParser(BaseClass):
 
         content = response.content
         if not content:
-            raise ParingError("Response has no content!", content=str(response))
+            raise ParsingError("Response has no content!", content=str(response))
         decoded_content = content.decode("utf-8")
 
         return BeautifulSoup(decoded_content, "html.parser")
@@ -216,7 +216,7 @@ class AsyncParser(BaseClass):
         breadcrumbs = schedule_page.find(attrs={"class": "breadcrumbs"})
 
         if not breadcrumbs:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no breadcrumbs! Can't determine faculty and group!",
                 content=str(schedule_page),
             )
@@ -226,7 +226,7 @@ class AsyncParser(BaseClass):
         table = schedule_page.find(attrs={"class": "table"})
 
         if not table:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no schedule table! Can't parse schedule!",
                 content=str(schedule_page),
             )
@@ -268,7 +268,7 @@ class AsyncParser(BaseClass):
 
         grid = schedule_page.find(name="div", attrs={"class": "grid"})
         if not grid:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no grid! Can't parse teacher's schedule!",
                 content=str(schedule_page),
             )
@@ -284,7 +284,7 @@ class AsyncParser(BaseClass):
         tiles = departments_page.find(attrs={"class": "tiles-grid"})
 
         if not tiles:
-            raise ParingError("No tiles found!", content=str(departments_page))
+            raise ParsingError("No tiles found!", content=str(departments_page))
 
         departments_tags = tiles.find_all(name="a", attrs={"data-role": "tile"})
 
@@ -305,7 +305,7 @@ class AsyncParser(BaseClass):
 
         teacher_tiles = teachers_page.find(attrs={"class": "tiles-grid"})
         if not teacher_tiles:
-            raise ParingError("No teachers found!", content=str(teachers_page))
+            raise ParsingError("No teachers found!", content=str(teachers_page))
 
         teacher_tiles = teacher_tiles.find_all(
             name="a",

--- a/src/ontu_parser/parser/sync.py
+++ b/src/ontu_parser/parser/sync.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from httpx import Response
+from httpx import HTTPStatusError, Response
 
 from ontu_parser.dataclasses import (
     Department,
@@ -37,10 +37,20 @@ class Parser(BaseClass):
             self.sender = RequestSender()
 
     def _get_page(self, response: Response) -> BeautifulSoup:
+        try:
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            raise ParingError(
+                "Failed to get page!",
+                content=str(response),
+                underlying_error=e,
+            ) from e
+
         content = response.content
         if not content:
             raise ParingError("Response has no content!", content=str(response))
         decoded_content = content.decode("utf-8")
+
         return BeautifulSoup(decoded_content, "html.parser")
 
     def is_on_break(self) -> bool:

--- a/src/ontu_parser/parser/sync.py
+++ b/src/ontu_parser/parser/sync.py
@@ -12,7 +12,7 @@ from ontu_parser.dataclasses import (
 from ontu_parser.dataclasses.base import BaseClass
 from ontu_parser.dataclasses.pair import StudentsPair, TeachersPair
 from ontu_parser.dataclasses.sender import SenderOptions
-from ontu_parser.errors import ParingError
+from ontu_parser.errors import ParsingError
 from ontu_parser.utils.request_sender import RequestSender
 
 
@@ -40,7 +40,7 @@ class Parser(BaseClass):
         try:
             response.raise_for_status()
         except HTTPStatusError as e:
-            raise ParingError(
+            raise ParsingError(
                 "Failed to get page!",
                 content=str(response),
                 underlying_error=e,
@@ -48,7 +48,7 @@ class Parser(BaseClass):
 
         content = response.content
         if not content:
-            raise ParingError("Response has no content!", content=str(response))
+            raise ParsingError("Response has no content!", content=str(response))
         decoded_content = content.decode("utf-8")
 
         return BeautifulSoup(decoded_content, "html.parser")
@@ -216,7 +216,7 @@ class Parser(BaseClass):
         breadcrumbs = schedule_page.find(attrs={"class": "breadcrumbs"})
 
         if not breadcrumbs:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no breadcrumbs! Can't determine faculty and group!",
                 content=str(schedule_page),
             )
@@ -226,7 +226,7 @@ class Parser(BaseClass):
         table = schedule_page.find(attrs={"class": "table"})
 
         if not table:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no schedule table! Can't parse schedule!",
                 content=str(schedule_page),
             )
@@ -262,7 +262,7 @@ class Parser(BaseClass):
 
         grid = schedule_page.find(name="div", attrs={"class": "grid"})
         if not grid:
-            raise ParingError(
+            raise ParsingError(
                 "Schedule page has no grid! Can't parse teacher's schedule!",
                 content=str(schedule_page),
             )
@@ -283,7 +283,7 @@ class Parser(BaseClass):
         departments_page = self._get_page(departments_response)
         titles = departments_page.find(attrs={"class": "tiles-grid"})
         if not titles:
-            raise ParingError("No titles found!", content=str(departments_page))
+            raise ParsingError("No titles found!", content=str(departments_page))
         departments_tags = titles.find_all(name="a", attrs={"data-role": "tile"})
         departments = []
         for tag in departments_tags:
@@ -301,7 +301,7 @@ class Parser(BaseClass):
         teachers_page = self._get_page(teachers_response)
         teachers_tags = teachers_page.find_all(attrs={"class": "tiles-grid"})
         if not teachers_tags:
-            raise ParingError("No teachers found!", content=str(teachers_page))
+            raise ParsingError("No teachers found!", content=str(teachers_page))
         teachers_tags = teachers_tags[0].find_all(
             name="a",
             attrs={"data-role": "tile"},

--- a/src/ontu_parser/parser/sync.py
+++ b/src/ontu_parser/parser/sync.py
@@ -14,6 +14,7 @@ from ontu_parser.dataclasses.pair import StudentsPair, TeachersPair
 from ontu_parser.dataclasses.sender import SenderOptions
 from ontu_parser.errors import ParsingError
 from ontu_parser.utils.request_sender import RequestSender
+from ontu_parser.utils.text import trim_text
 
 
 class Parser(BaseClass):
@@ -41,14 +42,24 @@ class Parser(BaseClass):
             response.raise_for_status()
         except HTTPStatusError as e:
             raise ParsingError(
-                "Failed to get page!",
-                content=str(response),
+                message=str(e),
+                content=trim_text(
+                    response.content.decode("utf-8", errors="ignore") if response.content else ""
+                ),
                 underlying_error=e,
             ) from e
 
         content = response.content
+
         if not content:
-            raise ParsingError("Response has no content!", content=str(response))
+            raise ParsingError(
+                "Response has no content!",
+                content=trim_text(
+                    response.content.decode("utf-8", errors="ignore") if response.content else ""
+                ),
+                underlying_error=None,
+            )
+
         decoded_content = content.decode("utf-8")
 
         return BeautifulSoup(decoded_content, "html.parser")

--- a/src/ontu_parser/utils/text.py
+++ b/src/ontu_parser/utils/text.py
@@ -1,0 +1,14 @@
+def trim_text(text: str, max_length: int = 1000) -> str:
+    """
+    Trims the input text to a specified maximum length.
+
+    Args:
+        text (str): The input text to be trimmed.
+        max_length (int): The maximum allowed length of the text. Default is 1000 characters.
+
+    Returns:
+        str: The trimmed text if it exceeds the maximum length, otherwise returns the original text.
+    """
+    if len(text) > max_length:
+        return text[: max_length - 3] + "..."
+    return text

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,38 @@
+import datetime
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import HTTPStatusError
+
+from ontu_parser.dataclasses.sender import SenderOptions
+from ontu_parser.errors import ParingError
+from ontu_parser.parser._async import AsyncParser
+
+
+@pytest_asyncio.fixture()
+async def async_parser_with_invalid_cookies() -> AsyncGenerator[AsyncParser, None]:
+    parser = AsyncParser(
+        sender_options=SenderOptions(
+            cookies={"invalid": "cookies"},
+            cookies_issued_at=datetime.datetime.now(tz=datetime.UTC),
+            max_cookie_retries=5,
+        )
+    )
+
+    try:
+        yield parser
+    finally:
+        await parser.sender.client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_parser_with_invalid_cookies(
+    async_parser_with_invalid_cookies: AsyncParser,
+) -> None:
+    with pytest.raises(ParingError) as exc_info:
+        await async_parser_with_invalid_cookies.get_faculties()
+
+    error = exc_info.value
+    assert isinstance(error.underlying_error, HTTPStatusError)
+    assert error.underlying_error.response.status_code == 503  # noqa: PLR2004

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -6,7 +6,7 @@ import pytest_asyncio
 from httpx import HTTPStatusError
 
 from ontu_parser.dataclasses.sender import SenderOptions
-from ontu_parser.errors import ParingError
+from ontu_parser.errors import ParsingError
 from ontu_parser.parser._async import AsyncParser
 
 
@@ -30,7 +30,7 @@ async def async_parser_with_invalid_cookies() -> AsyncGenerator[AsyncParser, Non
 async def test_async_parser_with_invalid_cookies(
     async_parser_with_invalid_cookies: AsyncParser,
 ) -> None:
-    with pytest.raises(ParingError) as exc_info:
+    with pytest.raises(ParsingError) as exc_info:
         await async_parser_with_invalid_cookies.get_faculties()
 
     error = exc_info.value

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -8,6 +8,7 @@ from httpx import HTTPStatusError
 from ontu_parser.dataclasses.sender import SenderOptions
 from ontu_parser.errors import ParsingError
 from ontu_parser.parser._async import AsyncParser
+from test.common import async_skip_on_break
 
 
 @pytest_asyncio.fixture()
@@ -28,8 +29,13 @@ async def async_parser_with_invalid_cookies() -> AsyncGenerator[AsyncParser, Non
 
 @pytest.mark.asyncio
 async def test_async_parser_with_invalid_cookies(
+    async_parser: AsyncParser,
     async_parser_with_invalid_cookies: AsyncParser,
 ) -> None:
+    # Using a "valid" parser to ensure that the test is not broken due to other reasons
+    if await async_skip_on_break(async_parser):
+        return
+
     with pytest.raises(ParsingError) as exc_info:
         await async_parser_with_invalid_cookies.get_faculties()
 

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "ontu-parser"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
This release adds status checks for rozklad.ontu.edu.ua responses, and slightly modifies the ParsingError (which was renamed to fix a typo) to include the underlying error.

:warning: Note that previous name (ParingError) is now deprecated, and it will be removed with 1.1.0 release

Changes:
- Added `raise_for_status` check in `_get_page` methods for sync and async parsers;
- Added `underlying_error` property to ParsingError;
- Renamed ParingError to ParsingError with compatibility alias left for now;
- Added new test to check that 503 error is handled properly for the case when provided cookies were no longer valid;
- Added `text` utilities with `trim_text` method;
- Bumped checkout and setup-python versions;
